### PR TITLE
【vertx-ignite】和【vertx-lang-kotlin-coroutines】的语法错误

### DIFF
--- a/docs/translation/vertx-ignite/java/index.adoc
+++ b/docs/translation/vertx-ignite/java/index.adoc
@@ -142,7 +142,7 @@ Ignite 的配置除了上述的 json 格式，也可以选用 XML 格式。
 </dependency>
 ----
 
-* Gradle （位于 `build.gradle `）：
+* Gradle （位于 `build.gradle` ）：
 
 [source,groovy,subs="+attributes"]
 ----

--- a/docs/translation/vertx-lang-kotlin-coroutines/kotlin/index.adoc
+++ b/docs/translation/vertx-lang-kotlin-coroutines/kotlin/index.adoc
@@ -484,7 +484,7 @@ launch {
 Vert.x 适用于任何协程构建器，如 `launch` ， `async` ， `produce` …… ，只要 `CoroutineScope` 实例是有效的。
 下面是几个注意事项：
 
-- 不要在 Vert.x 事件循环线程中使用`runBlocking`，因为这个方法不需要提供 `CoroutineScope` 。
+- 不要在 Vert.x 事件循环线程中使用 `runBlocking` ，因为这个方法不需要提供 `CoroutineScope` 。
 - 为了避免内存泄漏，请始终使用 `coroutineScope {..}` 来定义一个子作用域。这样，如果作用域中的一个协程失败，所有在该作用域中的协程也都会被取消。
 
 [[_coroutine_interoperability]]


### PR DESCRIPTION
修复 【vertx-ignite】和【vertx-lang-kotlin-coroutines】的 asciidoc 语法错误